### PR TITLE
[drivetrain] Prepare for Pigeon, fix+simplify field-relative driving

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -89,7 +89,7 @@ class ModuleConstants:
     # Gear Ratios / Mechanics
     kDrivingMotorPinionTeeth = 14
     kDrivingMotorReduction = 6.12
-    kTurningMotorReduction = 12.6
+    kTurningMotorReduction = 287 / 11.0  # this is for MK5n (but it would be 260 / 10.0 for MK5i)
 
     kWheelDiameterMeters = 0.0965
     kWheelCircumferenceMeters = kWheelDiameterMeters * math.pi

--- a/robotcontainer.py
+++ b/robotcontainer.py
@@ -97,8 +97,8 @@ class RobotContainer:
         self.robotDrive.setDefaultCommand(
             HolonomicDrive(
                 self.robotDrive,
-                forwardSpeed=lambda: self.driverController.getRawAxis(XboxController.Axis.kLeftY),
-                leftSpeed=lambda: self.driverController.getRawAxis(XboxController.Axis.kLeftX),
+                forwardSpeed=lambda: -self.driverController.getRawAxis(XboxController.Axis.kLeftY),
+                leftSpeed=lambda: -self.driverController.getRawAxis(XboxController.Axis.kLeftX),
                 rotationSpeed=lambda: self.driverController.getRawAxis(XboxController.Axis.kRightX),
                 deadband=OIConstants.kDriveDeadband,
                 fieldRelative=True,

--- a/subsystems/wrapped_navx.py
+++ b/subsystems/wrapped_navx.py
@@ -12,7 +12,8 @@ class Signal(object):
     status: StatusCode = StatusCode.OK
 
 
-GYRO_OVERSHOOT_FRACTION = 3.5 / 360   # example: if your gyro overshoots by 3.5 degrees on each 360 degree turn
+GYRO_OVERSHOOT_FRACTION = 0.0 / 360
+# ^^ example: set it = +3.5 / 360 if your NavX gyro overshoots by +3.5 degrees on each 360 degree turn
 
 
 class NavxGyro(Subsystem):

--- a/subsystems/wrapped_navx.py
+++ b/subsystems/wrapped_navx.py
@@ -12,12 +12,15 @@ class Signal(object):
     status: StatusCode = StatusCode.OK
 
 
+GYRO_OVERSHOOT_FRACTION = 3.5 / 360   # example: if your gyro overshoots by 3.5 degrees on each 360 degree turn
+
+
 class NavxGyro(Subsystem):
     """
     An attempt to extend NavX gyro to take a calibrated correction for overshoot, and work better in simulation.
     Imitates get_yaw/set_yaw interfaces of Pigeon2, so you can easily switch to Pigeon2 from this.
     """
-    def __init__(self, gyroOvershootFraction: float = 0.0) -> None:
+    def __init__(self, gyroOvershootFraction: float = GYRO_OVERSHOOT_FRACTION) -> None:
         """
         :param gyroOvershootFraction: if the gyro overshoots by 3.5 degrees on every full 360, set this to 3.5/360
         """

--- a/subsystems/wrapped_navx.py
+++ b/subsystems/wrapped_navx.py
@@ -1,0 +1,98 @@
+from dataclasses import dataclass
+
+from navx import AHRS
+from commands2 import Subsystem, TimedCommandRobot
+from wpilib import SmartDashboard, Timer
+from phoenix6 import StatusCode, StatusSignal
+
+
+@dataclass
+class Signal(object):
+    value: float = 0.0
+    status: StatusCode = StatusCode.OK
+
+
+class NavxGyro(Subsystem):
+    """
+    An attempt to extend NavX gyro to take a calibrated correction for overshoot, and work better in simulation.
+    Imitates get_yaw/set_yaw interfaces of Pigeon2, so you can easily switch to Pigeon2 from this.
+    """
+    def __init__(self, gyroOvershootFraction: float = 0.0) -> None:
+        """
+        :param gyroOvershootFraction: if the gyro overshoots by 3.5 degrees on every full 360, set this to 3.5/360
+        """
+        super().__init__()
+
+        self.gyro = AHRS.create_spi()
+        self.overshoot = gyroOvershootFraction
+
+        self.simulation = TimedCommandRobot.isSimulation()
+        self.time = 0
+        self.yaw = 0
+        self.adjustment = 0
+        self.state = "ok"
+
+        self.yaw_signal = Signal(0.0, StatusCode.OK)
+        self.speed_signal = Signal(0.0, StatusCode.OK)
+
+
+    def reset(self):
+        self.gyro.reset()
+        self.gyro.setAngleAdjustment(0)
+        self.adjustment = 0
+        self.time = 0
+        self.yaw = 0
+
+
+    def get_yaw(self) -> Signal:
+        """Returns the heading of the gyro, in degrees, tries to be smart when gyro is disconnected
+
+        :returns: Z axis heading as degrees
+        """
+        if self.simulation:
+            self.yaw_signal.value = self.yaw
+            return self.yaw_signal
+
+        now = Timer.getFPGATimestamp()
+        past = self.time
+        state = "ok"
+
+        if not self.gyro.isConnected():
+            state = "disconnected"
+        else:
+            notCalibrating = True
+            if self.gyro.isCalibrating():
+                notCalibrating = False
+                state = "calibrating"
+            gyroAngle = self.gyro.getAngle()
+
+            # correct for gyro drift
+            if self.overshoot != 0.0 and self.yaw != 0 and notCalibrating:
+                angleMove = gyroAngle - self.yaw
+                if abs(angleMove) > 15:  # if less than 10 degrees, adjust (otherwise it's some kind of glitch or reset)
+                    print(f"WARNING: big angle move {angleMove} from {self.yaw} to {gyroAngle}")
+                else:
+                    adjustment = -angleMove * self.overshoot
+                    self.adjustment += adjustment
+                    self.gyro.setAngleAdjustment(max(-359, min(+359, self.adjustment)))
+                    # ^^ NavX code doesn't like angle adjustments outside of (-360, +360) range
+
+            self.yaw = gyroAngle
+            self.time = now
+
+        if state != self.state:
+            SmartDashboard.putString("gyro", f"{state} after {int(now - past)}s")
+            self.state = state
+
+        self.yaw_signal.value = self.yaw
+        return self.yaw_signal
+
+
+    def set_yaw(self, yaw: float) -> None:
+        assert self.simulation
+        self.yaw = yaw
+
+
+    def get_angular_velocity_z_device(self) -> Signal:
+        self.speed_signal.value = self.gyro.getRate()
+        return self.speed_signal


### PR DESCRIPTION
1. This allows you to easily switch to Pigeon if you want (in `DriveSubsystem::__init__`)

2. This also allows you to add a correction for your NavX overshooting or under-shooting (for example, showing you +363.5 degrees when you did a 360 degree turn).
Each NavX we tested either overshoots or undershoots by a few degrees, so now you can easily correct for this in the code (otherwise your localization starts to suffer after you make ~5 robot rotations right or left, affecting approaches and aiming).

3. Fix the field-oriented driving orientation (we never need to reset it again now, instead it's always based on your alliance color).

Look at the picture below: best to orient your field this way in Elastic, because in simulation you are always *red* by default, unless you explicitly change this.
<img width="767" height="933" alt="image" src="https://github.com/user-attachments/assets/ef30f417-2b5d-45c8-9026-c823b3bc15a8" />


## NOTE ##
Alliance Color is something you can change from Driver Station when driving a real robot
<img width="683" height="338" alt="image" src="https://github.com/user-attachments/assets/5241e25f-3d45-4433-b28a-dfd7d10392af" />

In simulation you can change it in "FMS" tab of Robot Simulation window, but only when `state=Disconnected`:
<img width="363" height="459" alt="image" src="https://github.com/user-attachments/assets/e1acc5e4-ec20-4906-aa39-224d1297ee1c" />
