### PR TITLE
[drivetrain] expose who is resetting robot orientation (so we can fix)

### DIFF
--- a/buttonbindings.py
+++ b/buttonbindings.py
@@ -44,7 +44,8 @@ class ButtonBindings:
                 x=0.0,
                 y=0.0,
                 headingDegrees=0.0,
-                drivetrain=self.robotDrive
+                drivetrain=self.robotDrive,
+                reason="pov(0)"
             )
         )
 

--- a/commands/drive/reset_xy.py
+++ b/commands/drive/reset_xy.py
@@ -5,7 +5,7 @@ from wpimath.geometry import Rotation2d, Pose2d, Translation2d
 
 
 class ResetXY(commands2.Command):
-    def __init__(self, x, y, headingDegrees, drivetrain):
+    def __init__(self, x, y, headingDegrees, drivetrain, reason="no reason"):
         """
         Reset the starting (X, Y) and heading (in degrees) of the robot to where they should be.
         :param x: X
@@ -14,12 +14,13 @@ class ResetXY(commands2.Command):
         :param drivetrain: drivetrain on which the (X, Y, heading) should be set
         """
         super().__init__()
+        self.reason = reason
         self.drivetrain = drivetrain
         self.position = Pose2d(Translation2d(x, y), Rotation2d.fromDegrees(headingDegrees))
         self.addRequirements(drivetrain)
 
     def initialize(self):
-        self.drivetrain.resetOdometry(self.position)
+        self.drivetrain.resetOdometry(self.position, reason=self.reason)
 
     def isFinished(self) -> bool:
         return True  # this is an instant command, it finishes right after it initialized
@@ -43,7 +44,7 @@ class ResetSwerveFront(commands2.Command):
 
     def initialize(self):
         pose = self.drivetrain.getPose()
-        self.drivetrain.resetOdometry(pose)
+        self.drivetrain.resetOdometry(pose, reason="ResetSwerveFront")
 
     def isFinished(self) -> bool:
         return True  # this is an instant command, it finishes right after it initialized

--- a/robotcontainer.py
+++ b/robotcontainer.py
@@ -224,8 +224,8 @@ class RobotContainer:
         NamedCommands.registerCommand("SetIdle", self.superstructure.autoCreateStateCommand(RobotState.IDLE))
         NamedCommands.registerCommand("ElevatorUp", self.superstructure.autoCreateStateCommand(RobotState.ELEVATOR_RISING))
         NamedCommands.registerCommand("ElevatorDown", self.superstructure.autoCreateStateCommand(RobotState.ELEVATOR_LOWERING))
-        NamedCommands.registerCommand('ResetXYRed', ResetXY(8, 8, 180, self.robotDrive))
-        NamedCommands.registerCommand('ResetXYBlue', ResetXY(8, 8, 0, self.robotDrive))
+        NamedCommands.registerCommand('ResetXYRed', ResetXY(8, 8, 180, self.robotDrive, reason="ResetXYRed"))
+        NamedCommands.registerCommand('ResetXYBlue', ResetXY(8, 8, 0, self.robotDrive, reason="ResetXYBlue"))
 
         # PathPlanner Event Triggers
         EventTrigger("ElevatorUp").whileTrue(self.superstructure.autoCreateStateCommand(RobotState.ELEVATOR_RISING))

--- a/subsystems/drive/drivesubsystem.py
+++ b/subsystems/drive/drivesubsystem.py
@@ -234,7 +234,7 @@ class DriveSubsystem(Subsystem):
         """
         return self.odometry.getPose()
 
-    def resetOdometry(self, pose: Pose2d, resetGyro=True) -> None:
+    def resetOdometry(self, pose: Pose2d, resetGyro=True, reason="unknown") -> None:
         """Resets the odometry to the specified pose.
 
         :param pose: The pose to which to set the odometry.
@@ -255,18 +255,12 @@ class DriveSubsystem(Subsystem):
         )
         self.odometryHeadingOffset = self.odometry.getPose().rotation() - self.getGyroHeading()
 
+        SmartDashboard.putString("ResetXY", f"{int(pose.rotation().degrees())} deg: {reason}")
+
+
     def resetOdometryAuto(self, pose: Pose2d):
-        self.odometry.resetPosition(
-            self.getGyroHeading(),
-            (
-                self.frontLeft.getPosition(),
-                self.frontRight.getPosition(),
-                self.backLeft.getPosition(),
-                self.backRight.getPosition(),
-            ),
-            pose,
-        )
-        print(f"Angle{pose.rotation().degrees()}")
+        self.resetOdometry(pose, reason="PathPlanner")
+
 
     def adjustOdometry(self, dTrans: Translation2d, dRot: Rotation2d):
         """Adjusts the odometry by a specified translation and rotation delta.


### PR DESCRIPTION
in Elastic you need to add this "ResetXY" widget, and make sure it's wide enough, so your driving coach can take a screenshot or a phone picture of what's written inside of it after the end of the auto

<img width="316" height="153" alt="image" src="https://github.com/user-attachments/assets/d8a6b3a5-06b0-4b0b-87c5-ba3721309482" />
